### PR TITLE
Trim down CSS to only what's necessary

### DIFF
--- a/data/styles/app-stylesheet-dark.css
+++ b/data/styles/app-stylesheet-dark.css
@@ -1,23 +1,18 @@
 @define-color colorPrimary #2f3337;
 @define-color textColorPrimary #EFF0F1;
 
-.quilter-window {
-    background-color: @colorPrimary;
-}
 .quilter-toolbar {
     background-color: @colorPrimary;
-    background: @colorPrimary;
-    border-bottom-color: transparent;
     color: @textColorPrimary;
-    box-shadow: inset 0px 1px 1px 2px @colorPrimary;
 }
+
 actionbar,
-.action-bar,
-.quilter-statusbar {
-    background-color: @colorPrimary;
-    background-image: none;
+.action-bar {
     border-top-color: transparent;
     background: @colorPrimary;
     color: @textColorPrimary;
-    box-shadow: inset 0px 1px 1px 2px @colorPrimary;
+    box-shadow:
+        inset 1px 0 0 0 alpha (shade (@colorPrimary, 1.4), 0.6),
+        inset -1px 0 0 0 alpha (shade (@colorPrimary, 1.4), 0.6),
+        inset 0 -1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.8);
 }

--- a/data/styles/app-stylesheet.css
+++ b/data/styles/app-stylesheet.css
@@ -1,23 +1,18 @@
 @define-color colorPrimary #EFF0F1;
 @define-color textColorPrimary #4D4D4D;
 
-.quilter-window {
-    background-color: @colorPrimary;
-}
 .quilter-toolbar {
     background-color: @colorPrimary;
-    background: @colorPrimary;
-    border-bottom-color: transparent;
     color: @textColorPrimary;
-    box-shadow: inset 0px 1px 1px 2px @colorPrimary;
 }
+
 actionbar,
-.action-bar,
-.quilter-statusbar {
-    background-color: @colorPrimary;
-    background-image: none;
+.action-bar {
     border-top-color: transparent;
     background: @colorPrimary;
     color: @textColorPrimary;
-    box-shadow: inset 0px 1px 1px 2px @colorPrimary;
+    box-shadow:
+        inset 1px 0 0 0 alpha (shade (@colorPrimary, 1.4), 0.6),
+        inset -1px 0 0 0 alpha (shade (@colorPrimary, 1.4), 0.6),
+        inset 0 -1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.8);
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -148,8 +148,6 @@ namespace Quilter {
         }
 
         construct {
-            var context = this.get_style_context ();
-            context.add_class ("quilter-window");
             toolbar = new Gtk.HeaderBar ();
             var settings = AppSettings.get_default ();
             string cache = Path.build_filename (Environment.get_user_cache_dir (), "com.github.lainsce.quilter");
@@ -161,6 +159,7 @@ namespace Quilter {
             }
 
 			var header_context = toolbar.get_style_context ();
+            header_context.add_class (Gtk.STYLE_CLASS_FLAT);
             header_context.add_class ("quilter-toolbar");
 
             new_button = new Gtk.Button ();

--- a/src/Widgets/StatusBar.vala
+++ b/src/Widgets/StatusBar.vala
@@ -34,11 +34,6 @@ namespace Quilter {
             focusmode_item ();
         }
 
-        construct {
-            var context = this.get_style_context ();
-            context.add_class ("quilter-statusbar");
-        }
-
         public void wordcount_item () {
             wordcount_label = new Gtk.Label("");
             wordcount_label.set_width_chars (12);


### PR DESCRIPTION
This branches removes some unnecessary classes and styles:

* Remove `quilter-window` which does nothing since the window is covered completely with three widgets (headerbar, sourceview, statusbar)
* Use the built-in flat class to flatten the headerbar which makes some styles redundant
* Remove `quilter-statusbar` since the actionbar is already selected by `.action-bar` and `actionbar`
* Replace the box-shadow in the actionbar since drawing with `@colorPrimary` over a background of `@colorPrimary` does nothing