### PR TITLE
Focus only current sentence

### DIFF
--- a/data/com.github.lainsce.quilter.desktop
+++ b/data/com.github.lainsce.quilter.desktop
@@ -3,6 +3,7 @@ Name=Quilter
 Comment=Focus on your writing
 Comment[pt_BR]=Foque na sua escrita
 Comment[es]=Foque en su escritura
+Comment[pl]=Skup się na pisaniu
 Exec=com.github.lainsce.quilter %U
 Icon=com.github.lainsce.quilter
 Keywords=Text;Markdown;Editor;

--- a/data/com.github.lainsce.quilter.gschema.xml
+++ b/data/com.github.lainsce.quilter.gschema.xml
@@ -84,5 +84,9 @@
 			    <default>80</default>
 			    <summary>The margins for the Editor View</summary>
         </key>
+        <key name="focus-mode-type" type="i">
+			    <default>0</default>
+			    <summary>The type of Focus Mode</summary>
+        </key>
 		</schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,7 @@ executable(
     'src/Widgets/Cheatsheet.vala',
     'src/Styles/quilter.vala',
     'src/Styles/quilterdark.vala',
+    'src/Constants/FocusMode.vala',
     'src/Constants/AppSettings.vala',
     'src/Services/FileManager.vala',
     'src/Services/DialogUtils.vala',

--- a/po/com.github.lainsce.quilter.pot
+++ b/po/com.github.lainsce.quilter.pot
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Focus Mode"
 msgstr ""
 
-#: src/Widgets/Preferences.vala:47 src/Widgets/Preferences.vala:68
+#: src/Widgets/Preferences.vala:47 src/Widgets/Preferences.vala:67
 msgid "Editor"
 msgstr ""
 
@@ -277,3 +277,16 @@ msgstr ""
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr ""
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr ""
+

--- a/po/de.po
+++ b/po/de.po
@@ -277,3 +277,15 @@ msgstr "Wenn Sie nicht speichern, gehen alle Änderungen für immer verloren."
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr "Schließen ohne Speichern"
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -274,3 +274,15 @@ msgstr "Si no lo guardas, tus cambios se perderán"
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr "Cerrar sin guardar"
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -280,3 +280,15 @@ msgstr "Se non salvi, tutte le modifiche verranno perse."
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr "Chiudi senza salvare"
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -277,3 +277,15 @@ msgstr "Jeśli nie zapiszesz, zmiany zostaną utracone na zawsze."
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr "Zamknij bez zapisywania"
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr "Typ Fokusa"
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr "Zdanie"
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr "Paragraf"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -276,3 +276,15 @@ msgstr "Se não salvar, as mudanças se perderão para sempre."
 #: src/Services/DialogUtils.vala:83
 msgid "Close without saving"
 msgstr "Fechar sem Salvar"
+
+#: src/Widgets/Preferences.vala:185
+msgid "Type of Focus Mode:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:187
+msgid "Sentence"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:188
+msgid "Paragraph"
+msgstr ""

--- a/src/Constants/AppSettings.vala
+++ b/src/Constants/AppSettings.vala
@@ -35,6 +35,7 @@ namespace Quilter {
         public string last_file { get; set; }
         public string subtitle { get; set; }
         public string spellcheck_language { get; set; }
+        public FocusMode focus_mode_type { get; set; }
 
         private static AppSettings? instance;
         public static unowned AppSettings get_default () {

--- a/src/Constants/FocusMode.vala
+++ b/src/Constants/FocusMode.vala
@@ -1,0 +1,23 @@
+/*-
+ * Copyright (c) 2017 Lains
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Quilter {
+    public enum FocusMode {
+        PARAGRAPH,
+        SENTENCE
+    }
+}

--- a/src/Widgets/Preferences.vala
+++ b/src/Widgets/Preferences.vala
@@ -182,6 +182,38 @@ namespace Quilter.Widgets {
             var focus_mode = new SettingsSwitch ("focus-mode");
             var dark_mode_label = new SettingsLabel (_("Enable Dark Mode:"));
             var dark_mode = new SettingsSwitch ("dark-mode");
+            var focus_mode_type_label = new SettingsLabel (_("Type of Focus Mode:"));
+            var focus_mode_type_size = new Granite.Widgets.ModeButton ();
+            focus_mode_type_size.append_text (_("Paragraph"));
+            focus_mode_type_size.append_text (_("Sentence"));
+
+            var focus_mode_type = main_settings.focus_mode_type;
+
+            switch (focus_mode_type) {
+                case FocusMode.PARAGRAPH:
+                    focus_mode_type_size.selected = 0;
+                    break;
+                case FocusMode.SENTENCE:
+                    focus_mode_type_size.selected = 1;
+                    break;
+                default:
+                    focus_mode_type_size.selected = 0;
+                    break;
+            }
+
+            focus_mode_type_size.mode_changed.connect (() => {
+                switch (focus_mode_type_size.selected) {
+                    case 0:
+                        main_settings.focus_mode_type = FocusMode.PARAGRAPH;
+                        break;
+                    case 1:
+                        main_settings.focus_mode_type = FocusMode.SENTENCE;
+                        break;
+                    case 2:
+                        main_settings.focus_mode_type = focus_mode_type;
+                        break;
+                }
+            });
 
             var font_header = new Granite.HeaderLabel (_("Font"));
             var use_custom_font_label = new SettingsLabel (_("Custom font:"));
@@ -208,15 +240,17 @@ namespace Quilter.Widgets {
             interface_grid.attach (focus_mode, 1, 5, 1, 1);
             interface_grid.attach (dark_mode_label, 0, 6, 1, 1);
             interface_grid.attach (dark_mode, 1, 6, 1, 1);
+            interface_grid.attach (focus_mode_type_label, 0, 7, 1, 1);
+            interface_grid.attach (focus_mode_type_size, 1, 7, 1, 1);
 
-            interface_grid.attach (font_header, 0, 7, 3, 1);
-            interface_grid.attach (use_custom_font_label , 0, 8, 1, 1);
-            interface_grid.attach (use_custom_font, 1, 8, 1, 1);
-            interface_grid.attach (select_font, 2, 8, 1, 1);
+            interface_grid.attach (font_header, 0, 8, 3, 1);
+            interface_grid.attach (use_custom_font_label , 0, 9, 1, 1);
+            interface_grid.attach (use_custom_font, 1, 9, 1, 1);
+            interface_grid.attach (select_font, 2, 9, 1, 1);
 
-            interface_grid.attach (statusbar_header,  0, 9, 1, 1);
-            interface_grid.attach (statusbar_label,  0, 10, 1, 1);
-            interface_grid.attach (statusbar, 1, 10, 1, 1);
+            interface_grid.attach (statusbar_header,  0, 10, 1, 1);
+            interface_grid.attach (statusbar_label,  0, 11, 1, 1);
+            interface_grid.attach (statusbar, 1, 11, 1, 1);
 
             return interface_grid;
         }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -268,11 +268,11 @@ namespace Quilter.Widgets {
             if (cursor != null) {
                 var start_sentence = cursor_iter;
                 if (cursor_iter != start)
-                    start_sentence.backward_lines (1);
+                    start_sentence.backward_sentence_start ();
 
                 var end_sentence = cursor_iter;
                 if (cursor_iter != end)
-                    end_sentence.forward_lines (2);
+                    end_sentence.forward_sentence_end ();
 
                 if (!settings.dark_mode) {
                     buffer.apply_tag(lightgrayfont, start_sentence, end_sentence);

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -267,13 +267,36 @@ namespace Quilter.Widgets {
 
             if (cursor != null) {
                 var start_sentence = cursor_iter;
-                if (cursor_iter != start)
-                    start_sentence.backward_sentence_start ();
+                var focus_type = settings.focus_mode_type;
+                if (cursor_iter != start) {
+                    switch (focus_type) {
+                        case FocusMode.PARAGRAPH:
+                            start_sentence.backward_lines (1);
+                            break;
+                        case FocusMode.SENTENCE:
+                            start_sentence.backward_sentence_start ();
+                            break;
+                        default:
+                            start_sentence.backward_lines (1);
+                            break;
+                    }
+                }
 
                 var end_sentence = cursor_iter;
-                if (cursor_iter != end)
-                    end_sentence.forward_sentence_end ();
+                if (cursor_iter != end) {
+                    switch (focus_type) {
+                        case FocusMode.PARAGRAPH:
+                            end_sentence.forward_lines (2);
+                            break;
+                        case FocusMode.SENTENCE:
+                            end_sentence.forward_sentence_end ();
+                            break;
+                        default:
+                            end_sentence.forward_lines (2);
+                            break;
+                    }
 
+                }
                 if (!settings.dark_mode) {
                     buffer.apply_tag(lightgrayfont, start_sentence, end_sentence);
                     buffer.apply_tag(blackfont, start_sentence, end_sentence);


### PR DESCRIPTION
Focusing only current sentence gives much better results.
Last version of application could highlight 1 line back. It could
focus all paragraph instead only current sentence.

I hope so that you'll like this feature!

Focus before:
![selection_007](https://user-images.githubusercontent.com/317662/34864872-92f1e2d2-f776-11e7-8ab8-7a601ac100fe.png)

Focus right now:
![selection_006](https://user-images.githubusercontent.com/317662/34864882-9b220aea-f776-11e7-886b-9600f017230a.png)
