### PR TITLE
Add Typewriter Scrolling

### DIFF
--- a/data/com.github.lainsce.quilter.gschema.xml
+++ b/data/com.github.lainsce.quilter.gschema.xml
@@ -25,6 +25,11 @@
 				<summary>Focus Mode</summary>
 				<description>Whether Quilter should be in Focus Mode</description>
 			</key>
+	  <key name="typewriter-scrolling" type="b">
+				<default>false</default>
+				<summary>Typewriter Scrolling</summary>
+				<description>Whether Quilter should use Typewriter Scrolling</description>
+			</key>
 		<key name="dark-mode" type="b">
 				<default>false</default>
 				<summary>Dark Mode</summary>

--- a/src/Constants/AppSettings.vala
+++ b/src/Constants/AppSettings.vala
@@ -21,6 +21,9 @@ namespace Quilter {
         public const int NARROW_MARGIN = 5;
         public const int MEDIUM_MARGIN = 10;
         public const int WIDE_MARGIN = 15;
+
+        // Typewriter Position
+        public const double TYPEWRITER_POSITION = 0.65;
     }
 
     public class AppSettings : Granite.Services.Settings {
@@ -37,6 +40,7 @@ namespace Quilter {
         public bool highlight { get; set; }
         public bool use_system_font { get; set; }
         public bool shown_view { get; set; }
+        public bool typewriter_scrolling { get; set; }
         public int focus_mode_type { get; set; }
         public int margins { get; set; }
         public int spacing { get; set; }

--- a/src/Constants/AppSettings.vala
+++ b/src/Constants/AppSettings.vala
@@ -23,7 +23,7 @@ namespace Quilter {
         public const int WIDE_MARGIN = 15;
 
         // Typewriter Position
-        public const double TYPEWRITER_POSITION = 0.65;
+        public const double TYPEWRITER_POSITION = 0.60;
     }
 
     public class AppSettings : Granite.Services.Settings {

--- a/src/Widgets/Preferences.vala
+++ b/src/Widgets/Preferences.vala
@@ -273,6 +273,10 @@ namespace Quilter.Widgets {
                 }
             });
 
+            var typewriterscrolling_label = new SettingsLabel (_("Typewriter Scrolling:"));
+            typewriterscrolling_label.set_halign (Gtk.Align.END);
+            var typewriterscrolling = new SettingsSwitch ("typewriter-scrolling");
+
             var statusbar_header = new Granite.HeaderLabel (_("Headerbar & Statusbar"));
             var statusbar_label = new SettingsLabel (_("Show Statusbar:"));
             statusbar_label.set_halign (Gtk.Align.END);
@@ -312,11 +316,14 @@ namespace Quilter.Widgets {
             interface_grid.attach (focus_mode_type_label, 0, 6, 1, 1);
             interface_grid.attach (focus_mode_type_size, 1, 6, 1, 1);
 
-            interface_grid.attach (statusbar_header,  0, 7, 1, 1);
-            interface_grid.attach (statusbar_label,  0, 8, 1, 1);
-            interface_grid.attach (statusbar, 1, 8, 1, 1);
-            interface_grid.attach (show_file_label,  0, 9, 1, 1);
-            interface_grid.attach (show_file, 1, 9, 1, 1);
+            interface_grid.attach (typewriterscrolling_label, 0, 7, 1, 1);
+            interface_grid.attach (typewriterscrolling, 1, 7, 1, 1);
+
+            interface_grid.attach (statusbar_header,  0, 8, 1, 1);
+            interface_grid.attach (statusbar_label,  0, 9, 1, 1);
+            interface_grid.attach (statusbar, 1, 9, 1, 1);
+            interface_grid.attach (show_file_label,  0, 10, 1, 1);
+            interface_grid.attach (show_file, 1, 10, 1, 1);
 
             return interface_grid;
         }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -288,15 +288,15 @@ namespace Quilter.Widgets {
                 set_focused_text ();
             }
 
-            move_typewriter_scolling ();
+            if (settings.typewriter_scrolling) {
+                move_typewriter_scolling ();
+            }
         }
 
         public bool move_typewriter_scolling () {
             var settings = AppSettings.get_default ();
-            if (settings.typewriter_scrolling) {
-                var cursor = buffer.get_insert ();
-                this.scroll_to_mark(cursor, 0.0, true, 0.0, Constants.TYPEWRITER_POSITION);
-            }
+            var cursor = buffer.get_insert ();
+            this.scroll_to_mark(cursor, 0.0, true, 0.0, Constants.TYPEWRITER_POSITION);
             return settings.typewriter_scrolling;
         }
 

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -112,6 +112,7 @@ namespace Quilter.Widgets {
             buffer.changed.connect (() => {
                 is_modified = true;
                 on_text_modified ();
+                cursor_listener ();
             });
 
             darkgrayfont = buffer.create_tag(null, "foreground", "#393939");
@@ -212,13 +213,17 @@ namespace Quilter.Widgets {
                 var buffer_context = this.get_style_context ();
                 buffer_context.add_class ("small-text");
                 buffer_context.remove_class ("focus-text");
-                buffer.notify["cursor-position"].disconnect (set_focused_text);
+                buffer.notify["cursor-position"].connect (cursor_listener);
             } else {
                 set_focused_text ();
-                buffer.notify["cursor-position"].connect (set_focused_text);
                 var buffer_context = this.get_style_context ();
                 buffer_context.add_class ("focus-text");
                 buffer_context.remove_class ("small-text");
+                buffer.notify["cursor-position"].disconnect (cursor_listener);
+            }
+
+            if (settings.typewriter_scrolling) {
+                Timeout.add(500, move_typewriter_scolling);
             }
 
             set_scheme (get_default_scheme ());
@@ -274,6 +279,25 @@ namespace Quilter.Widgets {
             buffer.remove_tag(lightsepiafont, start, end);
             buffer.remove_tag(sepiafont, start, end);
             return "quilter";
+        }
+
+        public void cursor_listener () {
+            var settings = AppSettings.get_default ();
+
+            if (settings.focus_mode) {
+                set_focused_text ();
+            }
+
+            move_typewriter_scolling ();
+        }
+
+        public bool move_typewriter_scolling () {
+            var settings = AppSettings.get_default ();
+            if (settings.typewriter_scrolling) {
+                var cursor = buffer.get_insert ();
+                this.scroll_to_mark(cursor, 0.0, true, 0.0, Constants.TYPEWRITER_POSITION);
+            }
+            return settings.typewriter_scrolling;
         }
 
         public void set_focused_text () {

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -112,7 +112,6 @@ namespace Quilter.Widgets {
             buffer.changed.connect (() => {
                 is_modified = true;
                 on_text_modified ();
-                cursor_listener ();
             });
 
             darkgrayfont = buffer.create_tag(null, "foreground", "#393939");


### PR DESCRIPTION
Add support for Typewriter Scrolling (fixed scrolling).

![shot-typewriter-scrolling](https://user-images.githubusercontent.com/132455/41200519-c41479c0-6c5a-11e8-9fee-dca6586b6302.gif)

This hopefully allows writers to focus on writing.  Instead of wondering where the cursor is, it remains at a fixed position on the screen.

***Known Issues***: If typewriter scrolling is enabled and the user attempts to scroll, the window will move back to put the cursor in position.  I'm trying to see if there's an event to subscribe to or logic for identifying when the user is not using the keyboard.