### PR TITLE
Increase bottom margin when typewriter scrolling enabled.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -82,7 +82,7 @@ namespace Quilter {
             if (settings.typewriter_scrolling && settings.focus_mode) {
                 edit_view_content.bottom_margin = (int)(h * (1 - Constants.TYPEWRITER_POSITION));
             } else {
-                edit_view_content.bottom_margin = 0;
+                edit_view_content.bottom_margin = 40;
             }
 
             // Update file name

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -78,6 +78,13 @@ namespace Quilter {
             edit_view_content.left_margin = m;
             edit_view_content.right_margin = m;
 
+            // Update margins for typewriter scrolling
+            if (settings.typewriter_scrolling && settings.focus_mode) {
+                edit_view_content.bottom_margin = (int)(h * (1 - Constants.TYPEWRITER_POSITION));
+            } else {
+                edit_view_content.bottom_margin = 0;
+            }
+
             // Update file name
             if (settings.last_file != "" && settings.show_filename) {
 


### PR DESCRIPTION
This will allow the last line of text to be moved to the Constants.TYPEWRITER_POSITION on the screen.
![bottom_margin](https://user-images.githubusercontent.com/132455/41373900-7d20bd9a-6f06-11e8-8b69-3791c206307b.gif)
