### PR TITLE
Typerwriter scrolling support for empty document

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -80,9 +80,12 @@ namespace Quilter {
 
             // Update margins for typewriter scrolling
             if (settings.typewriter_scrolling && settings.focus_mode) {
-                edit_view_content.bottom_margin = (int)(h * (1 - Constants.TYPEWRITER_POSITION));
+                int titlebar_h = this.get_titlebar().get_allocated_height();
+                edit_view_content.bottom_margin = (int)(h * (1 - Constants.TYPEWRITER_POSITION)) - titlebar_h;
+                edit_view_content.top_margin = (int)(h * Constants.TYPEWRITER_POSITION) - titlebar_h;
             } else {
                 edit_view_content.bottom_margin = 40;
+                edit_view_content.top_margin = 40;
             }
 
             // Update file name


### PR DESCRIPTION
Add top margin support for typewriter scrolling.  This allows for typewriter scrolling with empty documents.

![valign-mid](https://user-images.githubusercontent.com/132455/41391158-c885d224-6f4d-11e8-82e2-6b48381950b6.png)
