### PR TITLE
fix Gdk.Key constants type mismatch with vala 0.42

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -356,7 +356,11 @@ namespace Quilter {
             this.show_all ();
         }
 
+#if VALA_0_42
+        protected bool match_keycode (uint keyval, uint code) {
+#else
         protected bool match_keycode (int keyval, uint code) {
+#endif
             Gdk.KeymapKey [] keys;
             Gdk.Keymap keymap = Gdk.Keymap.get_for_display (Gdk.Display.get_default ());
             if (keymap.get_entries_for_keyval (keyval, out keys)) {

--- a/src/Widgets/Cheatsheet.vala
+++ b/src/Widgets/Cheatsheet.vala
@@ -169,7 +169,11 @@ namespace Quilter.Widgets {
             }
         }
 
+#if VALA_0_42
+        protected bool match_keycode (uint keyval, uint code) {
+#else
         protected bool match_keycode (int keyval, uint code) {
+#endif
             Gdk.KeymapKey [] keys;
             Gdk.Keymap keymap = Gdk.Keymap.get_for_display (Gdk.Display.get_default ());
             if (keymap.get_entries_for_keyval (keyval, out keys)) {


### PR DESCRIPTION
This fixes errors with the in-development vala 0.42 compiler, occurring with vala 0.41.4 and later, and is backwards compatible with older versions of the compiler.