### PR TITLE
meson: drop lib prefix for libmarkdown

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ c_args = [
 
 # Find libMarkdown
 cc = meson.get_compiler('c')
-libmarkdown = cc.find_library('libmarkdown', required: true)
+libmarkdown = cc.find_library('markdown', required: true)
 
 # Let's define our executable
 add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], language: 'vala')


### PR DESCRIPTION
find_library wants the lib_name without the lib prefix