### PR TITLE
Treat new documents as unique

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-clear
-#meson build --prefix=/usr #GOBJECT_DEBUG=instance-count
-clear
-cd build
-ninja
-G_MESSAGES_DEBUG=all ./com.github.lainsce.quilter

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+clear
+#meson build --prefix=/usr #GOBJECT_DEBUG=instance-count
+clear
+cd build
+ninja
+G_MESSAGES_DEBUG=all ./com.github.lainsce.quilter

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -532,7 +532,12 @@ namespace Quilter {
                 dialog.run ();
             }
 
+            debug ("Creating new document");
+            on_save ();
             sidebar.add_file (Services.FileManager.get_temp_document_path ());
+            edit_view_content.text = "";
+            edit_view_content.modified = true;
+            on_save ();
         }
 
         private void on_open () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -532,8 +532,7 @@ namespace Quilter {
                 dialog.run ();
             }
 
-            Services.FileManager.get_cache_path ();
-            sidebar.add_file (Services.FileManager.get_cache_path ());
+            sidebar.add_file (Services.FileManager.get_temp_document_path ());
         }
 
         private void on_open () {

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -25,34 +25,38 @@ namespace Quilter.Services.FileManager {
     private static string? cache;
     public static string get_cache_path () {
         if (cache == null) {
-            cache = Path.build_filename (Environment.get_user_data_dir (), "com.github.lainsce.quilter", "temp.md");
+            cache = Path.build_filename (Environment.get_user_data_dir (), "com.github.lainsce.quilter");
             try {
             	string cachedirpath = Path.build_filename (Environment.get_user_data_dir (), "com.github.lainsce.quilter");
             	File cachedir = File.new_for_path (cachedirpath);
                 cachedir.make_directory_with_parents ();
                 FileUtils.set_contents (cache, "");
-            } catch (Error err) {
-                print ("Error writing file: " + err.message);
+            } catch (Error e) {
+                warning ("Error writing file: " + e.message);
             }
         }
 
         return cache;
     }
 
+    public static string get_temp_document_path () {
+        debug ("Generating a temp file path");
+        var name = new GLib.DateTime.now ();
+        return Path.build_filename (get_cache_path (), @"~$name.md");
+    }
+
     public void save_file (string path, string contents) throws Error {
         try {
             GLib.FileUtils.set_contents (path, contents);
-        } catch (Error err) {
-            print ("Error writing file: " + err.message);
+            debug (@"Saved file: $path");
+        } catch (Error e) {
+            var msg = e.message;
+            warning (@"Error writing file: $msg");
         }
     }
-    public void save_tmp_file (string contents = "") {
-        debug ("Saving cache...");
-        try {
-            save_file (get_cache_path (), contents);
-        } catch (Error e) {
-            warning ("Exception found: "+ e.message);
-        }
+
+    public bool is_temp_file (string path) {
+        return get_cache_path () in path;
     }
 
     // File I/O

--- a/src/Widgets/SideBar.vala
+++ b/src/Widgets/SideBar.vala
@@ -41,7 +41,6 @@ namespace Quilter.Widgets {
         private GLib.File file;
         private Gtk.Label no_files;
         private string[] files;
-        public string cache = Path.build_filename (Environment.get_user_data_dir (), "com.github.lainsce.quilter" + "/temp.md");
         public Gee.LinkedList<SideBarBox> s_files = null;
         public bool show_this {get; set; default = false;}
 
@@ -119,7 +118,7 @@ namespace Quilter.Widgets {
             column.set_placeholder (no_files);
 
             if (settings.current_file == "") {
-                filebox = new SideBarBox (this.win, Services.FileManager.get_cache_path ());
+                filebox = new SideBarBox (this.win, Services.FileManager.get_temp_document_path ());
                 column.insert (filebox, 1);
                 column.select_row (filebox);
             }

--- a/src/Widgets/SideBar.vala
+++ b/src/Widgets/SideBar.vala
@@ -245,7 +245,7 @@ namespace Quilter.Widgets {
                         } while (match.next ());
                     }
                 } catch (GLib.Error e) {
-                    GLib.error ("ERR: %s", e.message);
+                    warning ("ERR: %s", e.message);
                 }
             }
         }

--- a/src/Widgets/SideBarBox.vala
+++ b/src/Widgets/SideBarBox.vala
@@ -31,7 +31,7 @@ namespace Quilter.Widgets {
             }
             set {
                 _path = value;
-                if (_path == Services.FileManager.get_cache_path ()) {
+                if (Services.FileManager.is_temp_file (_path)) {
                     file_name_label.label = "New Document";
                     file_label.label = "New File";
                 } else {
@@ -43,11 +43,10 @@ namespace Quilter.Widgets {
 
         public string title {
             owned get {
-                if (path != Services.FileManager.get_cache_path ()) {
-                    return file_label.label;
-                } else {
+                if (Services.FileManager.is_temp_file (path))
                     return "New File";
-                }
+                else
+                    return file_label.label;
             }
         }
 

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -81,21 +81,17 @@ namespace Quilter.Widgets {
             settings.changed.connect (update_settings);
 
             try {
-                string text;
+                string text = "";
                 string file_path = settings.current_file;
+                
                 var file = File.new_for_path (file_path);
-
-                if (file.query_exists ()) {
-                    string filename = file.get_path ();
-                    GLib.FileUtils.get_contents (filename, out text);
-                    buffer.text = text;
-                    modified = false;
-                } else {
-                    Services.FileManager.save_tmp_file ();
-                    GLib.FileUtils.get_contents (Services.FileManager.get_cache_path (), out text);
-                    buffer.text = text;
-                    modified = false;
+                if (!file.query_exists ()) {
+                    Services.FileManager.save_file (file_path, "");
                 }
+                
+                GLib.FileUtils.get_contents (file.get_path (), out text);
+                buffer.text = text;
+                modified = false;
             } catch (Error e) {
                 warning ("Error: %s\n", e.message);
             }


### PR DESCRIPTION
This PR assigns timestamps for new documents, effectively implementing #266 because documents are no longer being overwritten as "temp.md" file.

This change can be also used to investigate issue #259 further.