### PR TITLE
DialogUtils translation fixes

### DIFF
--- a/src/Services/DialogUtils.vala
+++ b/src/Services/DialogUtils.vala
@@ -18,11 +18,11 @@ namespace Quilter.Services.DialogUtils {
     public Gtk.FileChooserDialog create_file_chooser (string title,
             Gtk.FileChooserAction action) {
         var chooser = new Gtk.FileChooserDialog (title, null, action);
-        chooser.add_button ("_Cancel", Gtk.ResponseType.CANCEL);
+        chooser.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
         if (action == Gtk.FileChooserAction.OPEN) {
-            chooser.add_button ("_Open", Gtk.ResponseType.ACCEPT);
+            chooser.add_button (_("Open"), Gtk.ResponseType.ACCEPT);
         } else if (action == Gtk.FileChooserAction.SAVE) {
-            chooser.add_button ("_Save", Gtk.ResponseType.ACCEPT);
+            chooser.add_button (_("Save"), Gtk.ResponseType.ACCEPT);
             chooser.set_do_overwrite_confirmation (true);
         }
         var filter1 = new Gtk.FileFilter ();


### PR DESCRIPTION
There's a translation problem in DialogUtils, I prepared a fix:

- [FIX] _("String") instead of "_String"
